### PR TITLE
Adjust spotlight abilities to disable features we don't want to offer

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,5 +4,11 @@ class Ability
     super
 
     can :manage, PurlResource, exhibit_id: user.roles.pluck(:exhibit_id) if user
+
+    # disable exhibit import/export
+    cannot :import, Spotlight::Exhibit unless user.superadmin?
+
+    # disable exhibit multi-tenancy.
+    cannot :create, Spotlight::Exhibit
   end
 end


### PR DESCRIPTION
Depends on sul-dlss/spotlight#929

This disables import/export as discussed.