### PR TITLE
Update alignment of widgets so they left align with main content area

### DIFF
--- a/app/assets/stylesheets/sul_theme.scss
+++ b/app/assets/stylesheets/sul_theme.scss
@@ -465,9 +465,6 @@ footer {
 
 // Curator Mode - Widgets //
 .content-block {
-  &.row {
-    margin-left: 0;
-  }
   margin-bottom: 10px;
   margin-top: 10px;
   img {
@@ -643,6 +640,10 @@ footer {
 
 .spotlight-flexbox.browse-categories .box {
   padding: 1em 6px;
+  @media screen and (min-width: $screen-lg-min) {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
   &:first-child {padding-left: 0;}
   &:last-child {padding-right: 0;}
 }


### PR DESCRIPTION
I think we've made other updates to Spotlight that make the CSS for widgets out-of-date and produce extra left padding:

### Before
![before](https://cloud.githubusercontent.com/assets/101482/7570778/9d41a148-f7c7-11e4-9261-3ca9cd1a4373.png)

### After
![after](https://cloud.githubusercontent.com/assets/101482/7570783/a91d37b6-f7c7-11e4-9909-10bf3b447ed3.png)

### Before
![before2](https://cloud.githubusercontent.com/assets/101482/7570791/b47a2b6e-f7c7-11e4-895a-403ea340d9c5.png)

### After
![after2](https://cloud.githubusercontent.com/assets/101482/7570794/b8c06454-f7c7-11e4-8743-3085c12a8f7a.png)
