### PR TITLE
fix rake reindex task

### DIFF
--- a/config/gdor.yml.example
+++ b/config/gdor.yml.example
@@ -17,11 +17,6 @@ harvestdor:
   # purl: url for the DOR purl server (used to get ContentMetadata, etc.)
   purl: https://purl.stanford.edu
 
-  # Additional options to pass to Faraday http client (https://github.com/technoweenie/faraday)
-  http_options:
-    ssl:
-      verify: false
-    # timeouts are in seconds;  timeout -> open/read, open_timeout -> connection open
-    request:
-      timeout: 180
-      open_timeout: 180
+# the severity level of messages to be logged.  Valid values are debug, info, warn, error, fatal
+# default: info (set in gdor-indexer)
+log_level: info

--- a/lib/tasks/spotlight.rake
+++ b/lib/tasks/spotlight.rake
@@ -30,18 +30,9 @@ namespace :spotlight do
       @exhibit_yml[::Rails.env].symbolize_keys
     end
 
-    Array(@exhibit_config[:sets]).each do |set|
-      indexer = Spotlight::Dor::Indexer.new
-      indexer.instance_variable_set(:@solr_client, Blacklight.solr)
-      indexer.config[:default_set] = set
-      indexer.send(:harvestdor_client).config[:default_set] = set
-
-      # Fix for faraday 0.9+
-      indexer.send(:harvestdor_client).config[:http_options].delete(:open_timeout)
-      indexer.send(:harvestdor_client).config[:http_options].delete(:timeout)
-
-      indexer.harvest_and_index
-    end
+    indexer = Spotlight::Dor::Indexer.new
+    indexer.instance_variable_set(:@solr_client, Blacklight.solr)
+    indexer.harvest_and_index
 
     Spotlight::SolrDocumentSidecar.group(:solr_document_id).find_each do |s|
       doc = SolrDocument.new id: s.solr_document_id


### PR DESCRIPTION
rake task referred to http_options in config, which are no longer needed and also cause an error due to construct and/or Hashie gems:    https://github.com/mbklein/confstruct/issues/27

@peetucket @cbeer 