### PR TITLE
add location_ssi as index_field (not as facet field)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -131,6 +131,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'box_ssi', label: 'Box'
     config.add_index_field 'folder_ssi', label: 'Folder'
     config.add_index_field 'folder_name_ssi', label: 'Folder Name'
+    config.add_index_field 'location_ssi', label: 'Location'
     config.add_index_field 'donor_tags_ssim', label: 'Donor tags'
 
     # "fielded" search configuration. Used by pulldown among other places.


### PR DESCRIPTION
This *should* have a unique value for each item and would make a lousy facet.  Unless we need it to be a facet field for exhibits configuration screen ...

@peetucket @cbeer 

connects to sul-dlss/spotlight-dor-resources#18