### PR TITLE
update spotlight-dor-resources to 0.0.4 (and its dependencies)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     ffi (1.9.10)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
-    gdor-indexer (0.2.0)
+    gdor-indexer (0.3.0)
       activesupport
       harvestdor-indexer
       hooks
@@ -243,7 +243,7 @@ GEM
       memoist (~> 0.12)
       multi_json (~> 1.11)
       signet (~> 0.6)
-    harvestdor (0.1.1)
+    harvestdor (0.1.2)
       confstruct
       nokogiri
     harvestdor-indexer (2.2.0)
@@ -458,7 +458,7 @@ GEM
       nokogiri
       stomp
       xml-simple
-    spotlight-dor-resources (0.0.3)
+    spotlight-dor-resources (0.0.4)
       blacklight-spotlight (~> 0.5)
       faraday
       gdor-indexer


### PR DESCRIPTION
gets us:
* location_ssi  indexed
* no more indexing log errors about dor content type
* use IIIF content metadata urls (for stacks images)

If this and #73 go in, we can deploy and reindex feigenbaum and have everything except full text.

@cbeer @peetucket  